### PR TITLE
Reset input form value

### DIFF
--- a/step2/client/components/ArticleForm.vue
+++ b/step2/client/components/ArticleForm.vue
@@ -34,6 +34,7 @@ export default {
   methods: {
     createArticle() {
       this.$store.dispatch('article/createArticle', { groupId: this.currentGroup.id, body: this.articleForm.body }).then((data) => {
+        this.articleForm.body = ''
         this.$store.dispatch('article/fetchArticles', { groupId: this.currentGroup.id })
       });
     }

--- a/step2/client/components/GroupList.vue
+++ b/step2/client/components/GroupList.vue
@@ -31,6 +31,7 @@ export default {
   methods: {
     createGroup() {
       this.$store.dispatch('group/createGroup', this.groupForm).then((data) => {
+        this.groupForm.name = ''
         this.$store.dispatch('group/fetchGroups').then((data) => {
           this.dialogVisible = false
           this.$refs['groupForm'].resetFields()


### PR DESCRIPTION
#1 です。

以下の2点のフォームの内容を常にリセット状態（空白）にしました。
- 新規グループ作成フォーム
- 記事投稿フォーム

`create` した直後に初期化しています。最初は描画時にリセットすればいいのでは、とライフサイクル周りを当たっていたのですが、そうではないとのことで、このような形になりました。
